### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "go"
+run = "go run ./example/*"

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ func main() {
 }
 
 ```
+[![Run on Repl.it](https://repl.it/badge/github/jabernardo/aargh)](https://repl.it/github/jabernardo/aargh)
 
 ## Test it out!
 ```sh


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@jabernardo/aargh).